### PR TITLE
feat(errors): add 404 not found error handling

### DIFF
--- a/error.go
+++ b/error.go
@@ -16,6 +16,7 @@ const (
 	ErrCodeSomethingWentWrong = "SOMETHING_WENT_WRONG"
 	ErrCodeBadRequest         = "BAD_REQUEST"
 	ErrCodeUnauthorized       = "UNAUTHORIZED"
+	ErrCodeNotFound           = "NOT_FOUND"
 )
 
 // Error message constants
@@ -23,6 +24,7 @@ const (
 	ErrMessageSomethingWentWrong = "Something went wrong"
 	ErrMessageBadRequest         = "Bad request"
 	ErrMessageUnauthorized       = "Unauthorized"
+	ErrMessageNotFound           = "Not Found"
 )
 
 const errMessageValidationFailed = "Key: '%s', Error: Validation for '%s' failed on the '%s' tag"
@@ -186,6 +188,9 @@ func ParseErrorResponse(err error) ErrorResponse {
 		case http.StatusUnauthorized:
 			resp.ErrorCode = ErrCodeUnauthorized
 			resp.ErrorMessage = ErrMessageUnauthorized
+		case http.StatusNotFound:
+			resp.ErrorCode = ErrCodeNotFound
+			resp.ErrorMessage = ErrMessageNotFound
 		default:
 			message := fmt.Sprintf("%v", err.Message)
 			if err.Internal != nil {


### PR DESCRIPTION
Added support for handling 404 Not Found errors by introducing ErrCodeNotFound and ErrMessageNotFound constants. This change allows the ParseErrorResponse function to map HTTP 404 status codes to the new standardized error code and message, improving consistency in error reporting.